### PR TITLE
Avoid duplicating responses when there are multiple consecutive epochs

### DIFF
--- a/responseCacher/cache.py
+++ b/responseCacher/cache.py
@@ -16,6 +16,7 @@ import json
 import requests
 
 from obspy import read_inventory
+from obspy.core import UTCDateTime
 from config import config
 
 if __name__ == "__main__":
@@ -72,6 +73,11 @@ if __name__ == "__main__":
             segment_length = 24 * 3600
         else:
             segment_length = 3600
+
+        t0 = starttime
+        t1 = endtime
+        starttime = (UTCDateTime(starttime)+1.0).isoformat()
+        endtime = (UTCDateTime(endtime)-1.0).isoformat()
 
         # Prepare to read inventory using ObsPy
         requestOptions = (

--- a/responseCacher/cache.py
+++ b/responseCacher/cache.py
@@ -94,6 +94,9 @@ if __name__ == "__main__":
         except:
             continue
 
+        starttime = t0
+        endtime = t1
+
         # Verify that only one channel is returned
         contents = inventory.get_contents()
         if len(contents["networks"]) != 1 or len(contents["stations"]) != 1 or len(contents["channels"]) != 1:
@@ -101,6 +104,7 @@ if __name__ == "__main__":
 
         # Get the first response object
         response = inventory[0][0][0].response
+
 
         # Call evalresp to evaluate the response
         # NFFT must be same as in Welch's method!


### PR DESCRIPTION
This pull request prevents duplicate responses by removing 1s from the start- and endtime of every epoch.

By getting the start/enddate from the fdsnws response, it is assumed that there are no consecutive multiple epochs with the same network.station.location.channel. However, sometimes this happens
(e.g. https://eida.gein.noa.gr/fdsnws/station/1/query?station=THE&format=text&level=channel )
In this case multiple lines are matched and multiple responses are extracted. For example in the following lines: 

```
HT|THE||HHE|40.6319|22.9628|132.0|0.0|90.0|0.0|Trillium 120P, 120 s, 1201 V/m/s-Trident, 40 Vpp (|480399000.0|1.0|M/S|100.0|2014-07-10T00:00:00|2015-10-20T00:00:00
HT|THE||HHE|40.6319|22.9628|132.0|0.0|90.0|0.0|CMG-3ESP, 100 s, 2000 V/m/s-Trident, 40 Vpp (gain|799998000.0|1.0|M/S|100.0|2015-10-20T00:00:00|2015-12-18T00:00:00
HT|THE||HHE|40.6319|22.9628|132.0|0.0|90.0|0.0|CMG-6T, 30s-100Hz, 2000 V/m/s-Trident, 40 Vpp (gai|799998000.0|1.0|M/S|100.0|2015-12-18T00:00:00|
```
when it will get to the 2nd line and check for responses between 2015-10-20T00:00:00 and 2015-12-18T00:00:00 it will include all three (the 1st because it has 2015-10-20T00:00:00 in it and the 3rd because it has 2015-12-18T00:00:00 in it.
