### PR TITLE
Avoid duplicating responses when there are multiple consecutive epochs

### DIFF
--- a/responseCacher/cache.py
+++ b/responseCacher/cache.py
@@ -16,6 +16,7 @@ import json
 import requests
 
 from obspy import read_inventory
+from obspy.core import UTCDateTime
 from config import config
 
 if __name__ == "__main__":
@@ -72,6 +73,11 @@ if __name__ == "__main__":
             segment_length = 24 * 3600
         else:
             segment_length = 3600
+
+        t0 = starttime
+        t1 = endtime
+        starttime = (UTCDateTime(starttime)+1.0).isoformat()
+        endtime = (UTCDateTime(endtime)-1.0).isoformat()
 
         # Prepare to read inventory using ObsPy
         requestOptions = (

--- a/responseCacher/cache.py
+++ b/responseCacher/cache.py
@@ -94,6 +94,9 @@ if __name__ == "__main__":
         except:
             continue
 
+        starttime = t0
+        endtime = t1
+
         # Verify that only one channel is returned
         contents = inventory.get_contents()
         if len(contents["networks"]) != 1 or len(contents["stations"]) != 1 or len(contents["channels"]) != 1:
@@ -101,6 +104,7 @@ if __name__ == "__main__":
 
         # Get the first response object
         response = inventory[0][0][0].response
+
 
         # Call evalresp to evaluate the response
         # NFFT must be same as in Welch's method!


### PR DESCRIPTION
This pull request prevents duplicate responses by removing 1s from the start- and endtime of every epoch and then restoring the original values immediately after the response request